### PR TITLE
Added FlareSolverr server support to allow bypassing Cloudflare challenges

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -18,4 +18,9 @@
         <setting id="importFavorites" label="Import Favorites" type="action" action="RunPlugin(plugin://plugin.video.rumble/?mode=9)"/>
         <setting id="inputstream_disable" label="Inputstream Disable" type="bool" default="False" />
     </category>
+    <category label="Cloudflare Bypass">
+        <setting id="bypassCloudflare" label="Enabled" type="bool" default="False"/>
+		<setting id="flareSolverrUrl" label="Flaresolverr URL" type="text" default="http://localhost:8191/v1"/>
+		<setting id="flareSolverrTimeout" label="Flaresolverr Timeout (s)" type="number" default="60"/>
+    </category>
 </settings>


### PR DESCRIPTION
I was having an issue with Cloudflare causing "Video not found" errors during certain times of the day. This was making the addon basically unusable except around midnight. I decided to try your suggestion of using Flaresolverr and it worked out well. It's very easy to setup in Docker. I think the userbase will be willing to go the extra few steps to keep the addon working.