### PR TITLE
Fixed two regex pattern warnings in the log

### DIFF
--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ def get_image( data, image_id ):
     """ method to get an image from scraped page's CSS from the image ID """
 
     image_re = re.compile(
-        "i.user-image--img--id-" + str( image_id ) + ".+?{\s*background-image: url(.+?);",
+        "i.user-image--img--id-" + str( image_id ) + r".+?{\s*background-image: url(.+?);",
         re.MULTILINE|re.DOTALL|re.IGNORECASE
     ).findall(data)
 
@@ -499,7 +499,7 @@ def get_video_id( url ):
 
     # gets embed id from embed url
     video_id = re.compile(
-        ',\"embedUrl\":\"' + BASE_URL + '/embed/(.*?)\/\",',
+        ',\"embedUrl\":\"' + BASE_URL + '/embed/(.*?)\\/\",',
         re.MULTILINE|re.DOTALL|re.IGNORECASE
     ).findall(data)
 


### PR DESCRIPTION
The following two warnings are popping up in the log:

2025-12-14 21:51:53.569 T:4574 error : :228:
2025-12-14 21:51:53.569 T:4574 error : SyntaxWarning
2025-12-14 21:51:53.569 T:4574 error : :
2025-12-14 21:51:53.569 T:4574 error : invalid escape sequence '\s'
2025-12-14 21:51:53.569 T:4574 error :
2025-12-14 21:51:53.569 T:4574 error :
2025-12-14 21:51:53.569 T:4574 error : "i.user-image--img--id-" + str( image_id ) + ".+?{\sbackground-image: url(.+?);",
2025-12-14 21:51:53.569 T:4574 error :
2025-12-14 21:51:53.571 T:4574 error : /home/ms/.var/app/tv.kodi.Kodi/data/addons/plugin.video.rumble/main.py
2025-12-14 21:51:53.571 T:4574 error : :502:
2025-12-14 21:51:53.571 T:4574 error : SyntaxWarning
2025-12-14 21:51:53.571 T:4574 error : :
2025-12-14 21:51:53.571 T:4574 error : invalid escape sequence '/'
2025-12-14 21:51:53.571 T:4574 error :
2025-12-14 21:51:53.571 T:4574 error :
2025-12-14 21:51:53.571 T:4574 error : ',"embedUrl":"' + BASE_URL + '/embed/(.?)/",',
2025-12-14 21:51:53.571 T:4574 error :
