### PR TITLE
Percent-encode dictionary post data sent to Flaresolverr

### DIFF
--- a/lib/general.py
+++ b/lib/general.py
@@ -75,7 +75,7 @@ def bypass_cloudflare(url, data):
             flaresolverr_data = { 'url': url, 'maxTimeout': 1000*timeout }
             if data:
                 flaresolverr_data['cmd'] = 'request.post'
-                flaresolverr_data['postData'] = data
+                flaresolverr_data['postData'] = urllib.parse.urlencode(data)
             else:
                 flaresolverr_data['cmd'] = 'request.get'
 


### PR DESCRIPTION
Potential fix for Issue #64: failure getting salts during login. Confirmed that post requests will fail when sent to Flaresolverr without percent-encoding first.